### PR TITLE
Update src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider....

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider.cs
@@ -1165,7 +1165,7 @@ namespace MvcSiteMapProvider
                     requestContext, routeData.Values);
                 string appPathPrefix = (requestContext.HttpContext.Request.ApplicationPath
                     ?? string.Empty).TrimEnd('/') + "/";
-                node = base.FindSiteMapNode(httpContext.Request.RawUrl) as MvcSiteMapNode;
+                node = base.FindSiteMapNode(httpContext.Request.Path) as MvcSiteMapNode;
 
                 if (!routeData.Values.ContainsKey("area"))
                 {


### PR DESCRIPTION
...cs

Hi, first pull request - be gentle! 

Fixed a potential bug around finding a root node. Change from Request.RawUrl to Request.Path

The scenario this affects is this:

Site root '/' maps to Controller/Action "Home/Index" that in turn performs a _Transfer_ to a controller/Action deeper in the site - previously the sitemap would reflect the position of the transferred  controller/Action
e.g. /Products/Browse

With the fix from issue #71 ("Checking for matching route values when finding the current node") , the above scenario now breaks (FindSiteMapNode returns null) .

This is because RawUrl in this case is "/", which resolves to the node at "Home/Index" but the route data is for a deeper node Controller = "Products", Action="Browse" - meaning the sitemap can't resolve a current node

Using Path correctly returns "/Products/Browse" which resolves the correct node "Products/Browse" which in turn matches the specifed routeData Controller="Products", Action ="Browse"

Does this make sense? Is it important to keep using RawUrl instead of Path?
