### PR TITLE
DefaultSiteMapProvider can't be refreshed if an exception was thrown

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider.cs
@@ -619,7 +619,17 @@ namespace MvcSiteMapProvider
                     {
                         throw new MvcSiteMapException(Resources.Messages.CouldNotDetermineRootNode);
                     }
-
+                }
+                catch (MvcSiteMapException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    throw new MvcSiteMapException(Resources.Messages.UnknownException, ex);
+                }
+                finally
+                {
                     // Create a cache item, this is used for the sole purpose of being able to invalidate our sitemap
                     // after a given time period, it also adds a dependancy on the sitemap file,
                     // so that once changed it will refresh your sitemap, unfortunately at this stage
@@ -640,19 +650,7 @@ namespace MvcSiteMapProvider
                                                   new CacheItemRemovedCallback(OnSiteMapChanged));
 
                     isBuildingSiteMap = false;
-                }
-                catch (MvcSiteMapException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    throw new MvcSiteMapException(Resources.Messages.UnknownException, ex);
-                }
-                finally
-                {
                     siteMapXml = null;
-                    isBuildingSiteMap = false;
                 }
             }
 


### PR DESCRIPTION
Currently an exception thrown while building (eg in a dynamicnodeprovider) will result in a sitemap being partially built without the cachekey being added, meaning that the refresh method won't work.

I moved the BuildSiteMap caching into the finally block. This allows exceptions to be caught and, if required by the application, for the sitemap to be refreshed.
