### PR TITLE
Fix for Issue #78, #67

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultControllerTypeResolver.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultControllerTypeResolver.cs
@@ -69,6 +69,10 @@ namespace MvcSiteMapProvider
             if (areaNamespaces != null)
             {
                 namespaces = new HashSet<string>(areaNamespaces, StringComparer.OrdinalIgnoreCase);
+                if (string.IsNullOrEmpty(areaName))
+    			{
+					namespaces = new HashSet<string>(namespaces.Union(ControllerBuilder.Current.DefaultNamespaces, StringComparer.OrdinalIgnoreCase), StringComparer.OrdinalIgnoreCase);
+				}
             }
             else if (ControllerBuilder.Current.DefaultNamespaces.Count > 0)
             {
@@ -107,17 +111,14 @@ namespace MvcSiteMapProvider
             var namespacesForArea = new List<string>();
             var namespacesCommon = new List<string>();
 
-            foreach (var route in routes.OfType<Route>().Where(r => r.DataTokens != null))
-            {
-                var areaToken = route.DataTokens["area"];
-                IEnumerable<string> namespacesToken = route.DataTokens["Namespaces"] == null ? new string[] { "" } : (IEnumerable<string>)route.DataTokens["Namespaces"];
-
-                // search for area-based namespaces
-                if (areaToken != null && areaToken.ToString().Equals(area, StringComparison.OrdinalIgnoreCase))
-                    namespacesForArea.AddRange(namespacesToken);
-                else if (areaToken == null)
-                    namespacesCommon.AddRange(namespacesToken);
-            }
+            foreach (var route in routes.OfType<Route>().Where(r => r.DataTokens != null && r.DataTokens["Namespaces"] != null))
+    		{
+				// search for area-based namespaces
+				if (route.DataTokens["area"] != null && route.DataTokens["area"].ToString().Equals(area, StringComparison.OrdinalIgnoreCase))
+					namespacesForArea.AddRange((IEnumerable<string>)route.DataTokens["Namespaces"]);
+				else if (route.DataTokens["area"] == null)
+					namespacesCommon.AddRange((IEnumerable<string>)route.DataTokens["Namespaces"]);
+			}
 
             if (namespacesForArea.Count > 0)
             {


### PR DESCRIPTION
The previous fix for #67 hid rather than fixed the problem and caused new issues for non-area controllers.

This fix reverts the previous edit and amends ResolveControllerType instead.

This should now allow type resolving properly in the following cases
*A non-area route provides namespaces
*Non-unique controller names appear inside and outside of an area

Problems will be caused in the following case:
*When non-area routes are to check only within a given namespace and not the defaultnamespaces

This is a much less common edgecase than either above case, it is bucking the "convention over configuration" view of MVC so comes with an expectation of more potential issues.
