### PR TITLE
Support controllers that are open generic types

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultControllerTypeResolver.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultControllerTypeResolver.cs
@@ -145,7 +145,7 @@ namespace MvcSiteMapProvider
                     {
                         List<Type> controllerTypes = GetListOfControllerTypes();
                         var groupedByName = controllerTypes.GroupBy(
-                            t => t.Name.Substring(0, t.Name.Length - "Controller".Length),
+                            t => t.Name.Substring(0, t.Name.IndexOf("Controller")),
                             StringComparer.OrdinalIgnoreCase);
                         AssemblyCache = groupedByName.ToDictionary(
                             g => g.Key,
@@ -178,7 +178,7 @@ namespace MvcSiteMapProvider
                 }
                 typesSoFar = typesSoFar.Concat(typesInAsm);
             }
-            return typesSoFar.Where(t => t != null && t.IsClass && t.IsPublic && !t.IsAbstract && t.Name.EndsWith("Controller", StringComparison.OrdinalIgnoreCase) && typeof(IController).IsAssignableFrom(t)).ToList();
+            return typesSoFar.Where(t => t != null && t.IsClass && t.IsPublic && !t.IsAbstract && t.Name.IndexOf("Controller", StringComparison.OrdinalIgnoreCase) != -1 && typeof(IController).IsAssignableFrom(t)).ToList();
         }
 
         /// <summary>

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider.cs
@@ -1627,7 +1627,7 @@ namespace MvcSiteMapProvider
             }
 
             // Determine controller and (index) action
-            string controller = type.Name.Replace("Controller", "");
+            string controller = type.Name.Substring(0, type.Name.IndexOf("Controller"));
             string action = (methodInfo != null ? methodInfo.Name : null) ?? "Index";
             if (methodInfo != null) // handle custom action name
             {


### PR DESCRIPTION
I've noticed that MvcSiteMapProvider doesn't support controllers that are instances of open generic types.  For instance, in a project I'm working on, I have a controller whose type signature is EmailController<TEmailModel>.  I use a custom controller factory to create instances of this controller.  The CLR name for this controller type is _EmailController`1_,  After digging around in the source code, I noticed that MvcSiteMapProvider currently expects the CLR type name of a controller type to end in 'Controller', which won't be the case if the controller type is an open generic.  I've therefore made some minor, non-breaking changes that should allow the use of controllers whose name follows the ASP.NET MVC controller naming convention and are instances of open generic types.
