### PR TITLE
Remove 'route' param from query string when routeName is supplied

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapNodeUrlResolver.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapNodeUrlResolver.cs
@@ -102,13 +102,15 @@ namespace MvcSiteMapProvider
             if (_urlkey == key) return _url;
 
             string returnValue;
+            var routeValueDictionary = new RouteValueDictionary(routeValues);
             if (!string.IsNullOrEmpty(mvcSiteMapNode.Route))
             {
-                returnValue = UrlHelper.RouteUrl(mvcSiteMapNode.Route, new RouteValueDictionary(routeValues));
+                routeValueDictionary.Remove("route");
+                returnValue = UrlHelper.RouteUrl(mvcSiteMapNode.Route, routeValueDictionary);
             }
             else
             {
-                returnValue = UrlHelper.Action(action, controller, new RouteValueDictionary(routeValues));
+                returnValue = UrlHelper.Action(action, controller, routeValueDictionary);
             }
 
             if (string.IsNullOrEmpty(returnValue))


### PR DESCRIPTION
When `mvcSiteMapNode` is populated with `route` attribute, it selects the correct route but adds it as a query param as well, e.g. `?route=bfs`.
This commit ensures route query param is removed only if route is present.
