### PR TITLE
Implementation of XML attribute inheritance

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider.cs
@@ -25,7 +25,15 @@ namespace MvcSiteMapProvider
     public class DefaultSiteMapProvider
         : StaticSiteMapProvider
     {
+        #region Attribute names
+
+        protected const string AttributesToInheritKey = "attributesToInherit";
+
+        #endregion
+
         #region Private
+
+        private readonly char[] configValueSeparators = new[] { ';', ',' };
 
         protected const string RootName = "mvcSiteMap";
         protected const string NodeName = "mvcSiteMapNode";
@@ -42,6 +50,8 @@ namespace MvcSiteMapProvider
         protected List<string> excludeAssembliesForScan = new List<string>();
         protected List<string> includeAssembliesForScan = new List<string>();
         protected List<string> attributesToIgnore = new List<string>();
+        protected string[] attributesToInherit = new string[0];
+
         #endregion
 
         #region Properties
@@ -294,6 +304,12 @@ namespace MvcSiteMapProvider
                 {
                     attributesToIgnore = tempAttributesToIgnore.Split(';', ',').ToList();
                 }
+            }
+
+            // Which attributes in the sitemap XML should be inherited from parent nodes?
+            if(!string.IsNullOrEmpty(attributes[AttributesToInheritKey]))
+            {
+                attributesToInherit = attributes[AttributesToInheritKey].Split(configValueSeparators);
             }
 
             // Is a node key generator given?
@@ -1449,6 +1465,11 @@ namespace MvcSiteMapProvider
             LoadInheritedAttribute("area", node, siteMapNode, parentMvcNode, defaultValue: string.Empty, isRouteValue: true);
             LoadInheritedAttribute("controller", node, siteMapNode, parentMvcNode, isRouteValue: true);
             LoadInheritedAttribute("action", node, siteMapNode, parentMvcNode, isRouteValue: true);
+
+            foreach(var attributeName in attributesToInherit)
+            {
+                LoadInheritedAttribute(attributeName, node, siteMapNode, parentMvcNode);
+            }
 
             // Add defaults for SiteMapNodeUrlResolver
             if (siteMapNode.UrlResolver == null)


### PR DESCRIPTION
Hello,

I'm using your Mvc.Sitemap provider library and recently faced the following problem:
I need my custom xml node attributes to be inherited from parent nodes, if there is no value in current node.
I've already implemented the functionality, so please verify it and tell me, if something is wrong (I've refactored the code a bit).

Short commit history:
1) Implement loading inherited attributes
- The attribute value is got from current node OR from the closest parent
  node which contains not-null/non-empty value
- Refactor getting inherited route values to remove several hard-coded
  strings and prevent copy-paste

2) Add config property to setup custom inherited attributes

Best regards,
Artyom
