### PR TITLE
Allow Multiple SiteMapTitleAttribute Instances on an Action

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/Filters/SiteMapTitleAttribute.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/Filters/SiteMapTitleAttribute.cs
@@ -16,7 +16,7 @@ namespace MvcSiteMapProvider.Filters
     /// Can be used for setting sitemap title on an action method.
     /// Credits go to Kenny Eliasson - http://mvcsitemap.codeplex.com/Thread/View.aspx?ThreadId=67056
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public class SiteMapTitleAttribute
         : ActionFilterAttribute
     {


### PR DESCRIPTION
A change to allow multiple instances of the SiteMapTitleAttribute on an Action in order to allow the setting the title of both the Parent and Current nodes. 

There are no checks elsewhere to make sure that there aren't multiple attributes targeted at the parent and/or current nodes. If there are, the order they are applied would be dictated by the Order parameter. If multiple attributes exist with the same order, the results are in determinant. 
