### PR TITLE
Fix for an issue #141 (if Url contains 'http' not only in schema part, but also in path, then <loc> value generated as relative path, instead of absolute in sitemap.xml)

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider.cs
@@ -1774,7 +1774,7 @@ namespace MvcSiteMapProvider
         protected bool EncodeExternalUrl(SiteMapNode node)
         {
             var url = node.Url;
-            if (url.Contains("http") || url.Contains("ftp"))
+            if (url.StartsWith("http") || url.StartsWith("ftp"))
             {
                 node.Url = HttpContext.Current.Server.UrlEncode(url);
                 return true;

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/XmlSiteMapResult.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/XmlSiteMapResult.cs
@@ -228,7 +228,7 @@ namespace MvcSiteMapProvider.Web
                 // Generate element
                 var siteMapNodeUrl = siteMapNode.Url;
                 string nodeUrl = url + siteMapNodeUrl;
-                if (siteMapNodeUrl.Contains("http") || siteMapNodeUrl.Contains("ftp"))
+                if (siteMapNodeUrl.StartsWith("http") || siteMapNodeUrl.StartsWith("ftp"))
                 {
                     nodeUrl = siteMapNodeUrl;
                 }


### PR DESCRIPTION
Just simple fix for issue: use .StartWith instead of .Contains when check for "http" (and "ftp") in the schema of Url
