### PR TITLE
V4 - Removed dead code from XmlSiteMapBuilder

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/Builder/XmlSiteMapBuilder.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/Builder/XmlSiteMapBuilder.cs
@@ -260,20 +260,6 @@ namespace MvcSiteMapProvider.Builder
         }
 
         /// <summary>
-        /// Acquires the roles list from a given XAttribute
-        /// </summary>
-        /// <param name="node">The attribute.</param>
-        /// <param name="roles">The roles IList to populate.</param>
-        protected virtual void AcquireRolesFrom(XAttribute attribute, IList<string> roles)
-        {
-            var localRoles = attribute.Value.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
-            foreach (var role in localRoles)
-            {
-                roles.Add(role);
-            }
-        }
-
-        /// <summary>
         /// Acquires the preserved route parameters list from a given XElement
         /// </summary>
         /// <param name="node">The node.</param>


### PR DESCRIPTION
I was reviewing the code and noticed a couple of methods in XmlSiteMapBuilder that were not being referenced and removed them. When it comes to code, less is more!
