### PR TITLE
Fix some minor mistakes

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/Html/Models/SiteMapNodeModel.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/Html/Models/SiteMapNodeModel.cs
@@ -14,9 +14,9 @@ namespace MvcSiteMapProvider.Web.Html.Models
         /// </summary>
         /// <param name="node">The node.</param>
         /// <param name="sourceMetadata">The source metadata provided by the HtmlHelper.</param>
-        public SiteMapNodeModel(ISiteMapNode node, IDictionary<string, object> sourceMetadata) 
-            : this(node, sourceMetadata, Int32.MaxValue, true) 
-        { 
+        public SiteMapNodeModel(ISiteMapNode node, IDictionary<string, object> sourceMetadata)
+            : this(node, sourceMetadata, Int32.MaxValue, true)
+        {
         }
 
         /// <summary>
@@ -61,8 +61,8 @@ namespace MvcSiteMapProvider.Web.Html.Models
         protected readonly ISiteMapNode node;
         protected readonly int maxDepth;
         protected readonly bool drillDownToCurrent;
-        protected readonly SiteMapNodeModelList descendants = new SiteMapNodeModelList();
-        protected readonly SiteMapNodeModelList ancestors = new SiteMapNodeModelList();
+        protected SiteMapNodeModelList descendants;
+        protected SiteMapNodeModelList ancestors;
         protected SiteMapNodeModelList children;
 
         /// <summary>
@@ -206,8 +206,8 @@ namespace MvcSiteMapProvider.Web.Html.Models
             get
             {
                 return node.ParentNode == null
-                    ? null 
-                    : new SiteMapNodeModel(node.ParentNode, SourceMetadata, maxDepth - 1, drillDownToCurrent);
+                    ? null
+                    : new SiteMapNodeModel(node.ParentNode, SourceMetadata, maxDepth == Int32.MaxValue ? Int32.MaxValue : maxDepth + 1, drillDownToCurrent);
             }
         }
 
@@ -218,7 +218,11 @@ namespace MvcSiteMapProvider.Web.Html.Models
         {
             get
             {
-                GetDescendants(this);
+                if (descendants == null)
+                {
+                    descendants = new SiteMapNodeModelList();
+                    GetDescendants(this);
+                }
                 return descendants;
             }
         }
@@ -230,7 +234,11 @@ namespace MvcSiteMapProvider.Web.Html.Models
         {
             get
             {
-                GetAncestors(this);
+                if (ancestors == null)
+                {
+                    ancestors = new SiteMapNodeModelList();
+                    GetAncestors(this);
+                }
                 return ancestors;
             }
         }


### PR DESCRIPTION
In Parent property, the maxDepth parameter pass to the contructor should
be increased 1.
In Descendents and Ancestors methods, the member variables should be
instantiated in get method.
