### PR TITLE
I am using some custom attributes in the config, and I added them to attributesToIgnore but had a space after my comma. It was failing the string compare because whitespace was not trimmed.

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/AuthorizeAttributeAclModule.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/AuthorizeAttributeAclModule.cs
@@ -57,19 +57,24 @@ namespace MvcSiteMapProvider
                 return true;
             }
 
-            // Is it an external node?
-            var nodeUrl = node.Url;
-            if (nodeUrl.StartsWith("http") || nodeUrl.StartsWith("ftp"))
-            {
-                return true;
-            }
-
             // Is it a regular node?
             var mvcNode = node as MvcSiteMapNode;
             if (mvcNode == null)
             {
                 throw new AclModuleNotSupportedException(
                     Resources.Messages.AclModuleDoesNotSupportRegularSiteMapNodes);
+            }
+
+            // Is it an external node?
+            var nodeUrl = mvcNode.Url;
+            if (null == nodeUrl)
+            {
+                throw new Exception(string.Format("NodeUrlResolver couldn't determine Url for Mvc SiteMap Node: {0}\nArea: {1}, Controller: {2}, Action: {3}", mvcNode, mvcNode.Area, mvcNode.Controller, mvcNode.Action));
+            }
+
+            if (nodeUrl.StartsWith("http") || nodeUrl.StartsWith("ftp"))
+            {
+                return true;
             }
 
             // Clickable? Always accessible.

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DefaultSiteMapProvider.cs
@@ -292,7 +292,7 @@ namespace MvcSiteMapProvider
                 var tempAttributesToIgnore = attributes["attributesToIgnore"];
                 if (!string.IsNullOrEmpty(tempAttributesToIgnore))
                 {
-                    attributesToIgnore = tempAttributesToIgnore.Split(';', ',').ToList();
+                    attributesToIgnore = tempAttributesToIgnore.Split(new[] {';', ',', ' '}, StringSplitOptions.RemoveEmptyEntries).ToList();
                 }
             }
 
@@ -462,6 +462,14 @@ namespace MvcSiteMapProvider
         {
             try
             {
+                if (null == node.Url)
+                {
+                    var mvcNode = node as MvcSiteMapNode;
+                    throw new Exception(
+                        string.Format("Couldn't resolve node Url\nArea: {0}, Controller: {1}, Action: {2}", mvcNode.Area,
+                                      mvcNode.Controller, mvcNode.Action));
+                }
+
                 // Avoid issue with url table not clearing correctly.
                 if (base.FindSiteMapNode(node.Url) != null)
                 {


### PR DESCRIPTION
- Add extra error messaging for debugging MvcSiteMapProvider exceptions
  around Route Urls
- Trim whitespace on attributesToIgnore values
