### PR TITLE
Update MenuHelper.cs -- fix for allowForwardSearch not being passed

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/Html/MenuHelper.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/Html/MenuHelper.cs
@@ -687,7 +687,7 @@ namespace MvcSiteMapProvider.Web.Html
         /// <returns>Html markup</returns>
         public static MvcHtmlString Menu(this MvcSiteMapHtmlHelper helper, string templateName, int startingNodeLevel, int maxDepth, bool allowForwardSearch, bool drillDownToCurrent, SourceMetadataDictionary sourceMetadata)
         {
-            ISiteMapNode startingNode = GetStartingNode(GetCurrentNode(helper.SiteMap), startingNodeLevel, false);
+            ISiteMapNode startingNode = GetStartingNode(GetCurrentNode(helper.SiteMap), startingNodeLevel, allowForwardSearch);
             if (startingNode == null)
             {
                 return MvcHtmlString.Empty;


### PR DESCRIPTION
When using this particular overload, the allowForwardSearch parameter is not passed through to the GetStartingNode method that is called.  This renders the parameter meaningless.
