### PR TITLE
Sitemap page links are broken when application is hosted as sub application

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/Mvc/XmlSiteMapResult.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/Mvc/XmlSiteMapResult.cs
@@ -22,7 +22,8 @@ namespace MvcSiteMapProvider.Web.Mvc
             IEnumerable<string> siteMapCacheKeys,
             string baseUrl,
             string siteMapUrlTemplate,
-            ISiteMapLoader siteMapLoader)
+            ISiteMapLoader siteMapLoader,
+            IUrlPath urlPath)
         {
             if (siteMapLoader == null)
                 throw new ArgumentNullException("siteMapLoader");
@@ -34,9 +35,12 @@ namespace MvcSiteMapProvider.Web.Mvc
             this.BaseUrl = baseUrl;
             this.SiteMapUrlTemplate = siteMapUrlTemplate;
             this.siteMapLoader = siteMapLoader;
+            this.urlPath = urlPath;
         }
 
         private readonly ISiteMapLoader siteMapLoader;
+
+        private readonly IUrlPath urlPath;
 
         /// <summary>
         /// Maximal number of links per sitemap file.
@@ -106,7 +110,7 @@ namespace MvcSiteMapProvider.Web.Mvc
 
             // Generate sitemap sitemapindex
             var sitemapIndex = new XElement(Ns + "sitemapindex");
-            sitemapIndex.Add(GenerateSiteMapIndexElements(Convert.ToInt32(numPages), BaseUrl, SiteMapUrlTemplate).ToArray());
+            sitemapIndex.Add(GenerateSiteMapIndexElements(Convert.ToInt32(numPages), SiteMapUrlTemplate).ToArray());
 
             // Generate sitemap
             var xmlSiteMap = new XDocument(
@@ -210,16 +214,15 @@ namespace MvcSiteMapProvider.Web.Mvc
         /// Generates the sitemap index elements.
         /// </summary>
         /// <param name="numPages">The number of pages.</param>
-        /// <param name="url">The URL.</param>
         /// <param name="siteMapUrlTemplate">The site map URL template.</param>
         /// <returns>The sitemap index elements.</returns>
-        protected virtual IEnumerable<XElement> GenerateSiteMapIndexElements(int numPages, string url, string siteMapUrlTemplate)
+        protected virtual IEnumerable<XElement> GenerateSiteMapIndexElements(int numPages, string siteMapUrlTemplate)
         {
             // Generate elements
             for (int i = 1; i <= numPages; i++)
             {
-                yield return new XElement(Ns + "sitemap",
-                    new XElement(Ns + "loc", url + "/" + siteMapUrlTemplate.Replace("{page}", i.ToString())));
+                var pageUrl = urlPath.MakeRelativeUrlAbsolute("~/" + siteMapUrlTemplate.Replace("{page}", i.ToString()));
+                yield return new XElement(Ns + "sitemap", new XElement(Ns + "loc", pageUrl));
             }
         }
 

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/Mvc/XmlSiteMapResultFactory.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/Mvc/XmlSiteMapResultFactory.cs
@@ -40,7 +40,8 @@ namespace MvcSiteMapProvider.Web.Mvc
                 this.DefaultSiteMapCacheKeys,
                 this.DefaultBaseUrl,
                 this.DefaultSiteMapUrlTemplate,
-                this.siteMapLoader);
+                this.siteMapLoader,
+                this.urlPath);
         }
 
         public ActionResult Create(int page)
@@ -51,7 +52,8 @@ namespace MvcSiteMapProvider.Web.Mvc
                 this.DefaultSiteMapCacheKeys,
                 this.DefaultBaseUrl,
                 this.DefaultSiteMapUrlTemplate,
-                this.siteMapLoader);
+                this.siteMapLoader,
+                this.urlPath);
         }
 
         public virtual ActionResult Create(IEnumerable<string> siteMapCacheKeys)
@@ -62,7 +64,8 @@ namespace MvcSiteMapProvider.Web.Mvc
                 siteMapCacheKeys,
                 this.DefaultBaseUrl,
                 this.DefaultSiteMapUrlTemplate,
-                this.siteMapLoader);
+                this.siteMapLoader,
+                this.urlPath);
         }
 
         public ActionResult Create(int page, IEnumerable<string> siteMapCacheKeys)
@@ -73,7 +76,8 @@ namespace MvcSiteMapProvider.Web.Mvc
                 siteMapCacheKeys,
                 this.DefaultBaseUrl,
                 this.DefaultSiteMapUrlTemplate,
-                this.siteMapLoader);
+                this.siteMapLoader,
+                this.urlPath);
         }
 
         public virtual ActionResult Create(IEnumerable<string> siteMapCacheKeys, string baseUrl, string siteMapUrlTemplate)
@@ -84,7 +88,8 @@ namespace MvcSiteMapProvider.Web.Mvc
                 siteMapCacheKeys,
                 baseUrl,
                 siteMapUrlTemplate,
-                this.siteMapLoader);
+                this.siteMapLoader,
+                this.urlPath);
         }
 
         public ActionResult Create(int page, IEnumerable<string> siteMapCacheKeys, string baseUrl, string siteMapUrlTemplate)
@@ -95,7 +100,8 @@ namespace MvcSiteMapProvider.Web.Mvc
                 siteMapCacheKeys,
                 baseUrl,
                 siteMapUrlTemplate,
-                this.siteMapLoader);
+                this.siteMapLoader,
+                this.urlPath);
         }
 
         public virtual ActionResult Create(ISiteMapNode rootNode)
@@ -106,7 +112,8 @@ namespace MvcSiteMapProvider.Web.Mvc
                 this.DefaultSiteMapCacheKeys,
                 this.DefaultBaseUrl,
                 this.DefaultSiteMapUrlTemplate,
-                this.siteMapLoader);
+                this.siteMapLoader,
+                this.urlPath);
         }
 
         public ActionResult Create(int page, ISiteMapNode rootNode)
@@ -117,7 +124,8 @@ namespace MvcSiteMapProvider.Web.Mvc
                 this.DefaultSiteMapCacheKeys,
                 this.DefaultBaseUrl,
                 this.DefaultSiteMapUrlTemplate,
-                this.siteMapLoader);
+                this.siteMapLoader,
+                this.urlPath);
         }
 
         public virtual ActionResult Create(ISiteMapNode rootNode, string baseUrl, string siteMapUrlTemplate)
@@ -128,7 +136,8 @@ namespace MvcSiteMapProvider.Web.Mvc
                 this.DefaultSiteMapCacheKeys,
                 baseUrl,
                 siteMapUrlTemplate,
-                this.siteMapLoader);
+                this.siteMapLoader,
+                this.urlPath);
         }
 
         public ActionResult Create(int page, ISiteMapNode rootNode, string baseUrl, string siteMapUrlTemplate)
@@ -139,7 +148,8 @@ namespace MvcSiteMapProvider.Web.Mvc
                 this.DefaultSiteMapCacheKeys,
                 baseUrl,
                 siteMapUrlTemplate,
-                this.siteMapLoader);
+                this.siteMapLoader,
+                this.urlPath);
         }
 
         #endregion


### PR DESCRIPTION
When sitemap is broken into pages, page URLs are not generated correctly. They are just added to the end of domain. These links do not work when application is hosted inside another website. 

![sb1](https://f.cloud.github.com/assets/1431130/1048732/575e77b4-1092-11e3-86e1-ed692d259343.png)
![sb2](https://f.cloud.github.com/assets/1431130/1048733/5abb8618-1092-11e3-9d49-cd9ad8a978be.png)

I fixed this by injecting IUrlPath into XmlSiteMapResult and using it to generate page links. It fixes the problem but you may have a better solution.
