### PR TITLE
VisibilityAffectsDescendants behavior now configurable for XmlSiteMapResult

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/Builder/SiteMapBuilderSet.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/Builder/SiteMapBuilderSet.cs
@@ -10,12 +10,13 @@ namespace MvcSiteMapProvider.Builder
         : ISiteMapBuilderSet
     {
         public SiteMapBuilderSet(
-            string instanceName,
-            bool securityTrimmingEnabled,
-            bool enableLocalization,
-            ISiteMapBuilder siteMapBuilder,
-            ICacheDetails cacheDetails
-            )
+           string instanceName,
+           bool securityTrimmingEnabled,
+           bool enableLocalization,
+           bool visibilityAffectsDescendants,
+           ISiteMapBuilder siteMapBuilder,
+           ICacheDetails cacheDetails
+           )
         {
             if (string.IsNullOrEmpty(instanceName))
                 throw new ArgumentNullException("instanceName");
@@ -27,13 +28,36 @@ namespace MvcSiteMapProvider.Builder
             this.instanceName = instanceName;
             this.securityTrimmingEnabled = securityTrimmingEnabled;
             this.enableLocalization = enableLocalization;
+            this.visibilityAffectsDescendants = visibilityAffectsDescendants;
             this.siteMapBuilder = siteMapBuilder;
             this.cacheDetails = cacheDetails;
         }
 
+        /// <summary>
+        /// ctor for backwards compatibility, 
+        /// visibilityAffectsDescendants parameter defaults to false
+        /// </summary>
+        [Obsolete]
+        public SiteMapBuilderSet(
+            string instanceName,
+            bool securityTrimmingEnabled,
+            bool enableLocalization,
+            ISiteMapBuilder siteMapBuilder,
+            ICacheDetails cacheDetails
+            ) :
+            this(
+            instanceName,
+            securityTrimmingEnabled,
+            enableLocalization,
+            false,
+            siteMapBuilder,
+            cacheDetails) { }
+
+
         protected readonly string instanceName;
         protected readonly bool securityTrimmingEnabled;
         protected readonly bool enableLocalization;
+        protected readonly bool visibilityAffectsDescendants;
         protected readonly ISiteMapBuilder siteMapBuilder;
         protected readonly ICacheDetails cacheDetails;
 
@@ -58,6 +82,11 @@ namespace MvcSiteMapProvider.Builder
         public virtual bool EnableLocalization
         {
             get { return this.enableLocalization; }
+        }
+
+        public virtual bool VisibilityAffectsDescendants
+        {
+            get { return this.visibilityAffectsDescendants; }
         }
 
         public virtual bool AppliesTo(string builderSetName)

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DI/ConfigurationSettings.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DI/ConfigurationSettings.cs
@@ -30,6 +30,7 @@ namespace MvcSiteMapProvider.DI
             this.DefaultSiteMapNodeVisibiltyProvider = GetConfigurationValueOrFallback("MvcSiteMapProvider_DefaultSiteMapNodeVisibiltyProvider", String.Empty);
             this.EnableLocalization = bool.Parse(GetConfigurationValueOrFallback("MvcSiteMapProvider_EnableLocalization", "true"));
             this.SecurityTrimmingEnabled = bool.Parse(GetConfigurationValueOrFallback("MvcSiteMapProvider_SecurityTrimmingEnabled", "false"));
+            this.VisibilityAffectsDescendants = bool.Parse(GetConfigurationValueOrFallback("MvcSiteMapProvider_VisibilityAffectsDescendants", "false"));
             this.EnableSitemapsXml = bool.Parse(GetConfigurationValueOrFallback("MvcSiteMapProvider_EnableSitemapsXml", "true"));
             this.EnableResolvedUrlCaching = bool.Parse(GetConfigurationValueOrFallback("MvcSiteMapProvider_EnableResolvedUrlCaching", "true"));
         }
@@ -48,6 +49,7 @@ namespace MvcSiteMapProvider.DI
         public string DefaultSiteMapNodeVisibiltyProvider { get; private set; }
         public bool EnableLocalization { get; private set; }
         public bool SecurityTrimmingEnabled { get; private set; }
+        public bool VisibilityAffectsDescendants { get; private set; }
         public bool EnableSitemapsXml { get; private set; }
         public bool EnableResolvedUrlCaching { get; private set; }
 

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DI/SiteMapLoaderContainer.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DI/SiteMapLoaderContainer.cs
@@ -97,6 +97,7 @@ namespace MvcSiteMapProvider.DI
                         "default", 
                         settings.SecurityTrimmingEnabled, 
                         settings.EnableLocalization,
+                        settings.VisibilityAffectsDescendants,
                         this.ResolveSiteMapBuilder(settings),
                         this.ResolveCacheDetails(settings)
                         )

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/ISiteMap.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/ISiteMap.cs
@@ -39,6 +39,7 @@ namespace MvcSiteMapProvider
         bool IsAccessibleToUser(ISiteMapNode node);
         string ResourceKey { get; set; }
         bool SecurityTrimmingEnabled { get; }
+        bool VisibilityAffectsDescendants { get; }
         Type ResolveControllerType(string areaName, string controllerName);
         IEnumerable<string> ResolveActionMethodParameters(string areaName, string controllerName, string actionMethodName);
     }

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/ISiteMapSettings.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/ISiteMapSettings.cs
@@ -6,5 +6,6 @@ namespace MvcSiteMapProvider
     {
         bool SecurityTrimmingEnabled { get; }
         bool EnableLocalization { get; }
+        bool VisibilityAffectsDescendants { get; }
     }
 }

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/SiteMap.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/SiteMap.cs
@@ -582,6 +582,14 @@ namespace MvcSiteMapProvider
         }
 
         /// <summary>
+        /// Gets a Boolean value indicating whether the visibility property of the current node
+        /// will affect the descendant nodes.
+        /// </summary>
+        public bool VisibilityAffectsDescendants {
+            get { return this.siteMapSettings.VisibilityAffectsDescendants; }
+        }
+
+        /// <summary>
         /// Resolves the controller type based on the current SiteMap instance.
         /// </summary>
         /// <remarks>There is 1 instance of controller type resolver per site map.</remarks>

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/Mvc/XmlSiteMapResult.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/Mvc/XmlSiteMapResult.cs
@@ -193,7 +193,7 @@ namespace MvcSiteMapProvider.Web.Mvc
                     {
                         throw new UnknownSiteMapException(Resources.Messages.UnknownSiteMap);
                     }
-                    visibilityAffectsDescendants = false;// siteMap.VisibilityAffectsDescendants;
+                    visibilityAffectsDescendants = siteMap.VisibilityAffectsDescendants;
                     RootNode = siteMap.RootNode;
                     foreach (var item in FlattenHierarchy(this.RootNode, context))
                     {
@@ -203,7 +203,7 @@ namespace MvcSiteMapProvider.Web.Mvc
             }
             else
             {
-                visibilityAffectsDescendants = false; //siteMapLoader.GetSiteMap().VisibilityAffectsDescendants;
+                visibilityAffectsDescendants = siteMapLoader.GetSiteMap().VisibilityAffectsDescendants;
                 foreach (var item in FlattenHierarchy(this.RootNode, context))
                 {
                     flattenedHierarchy.Add(item);


### PR DESCRIPTION
Added visibilityAffectsDescendants logic to XmlSiteMapResult (flattenhierarchy). Value for the property can be set through configuration. Html helpers are not (yet) using this property. Default behavior for XmlSiteMapResult (false) is different from the Html helpers (true), what should the default be for both?
A test still needs to be written to confirm current behavior isn't broken but the change wasn't all that complicated after all.
