### PR TITLE
Support an option to use case insensitive match for url.

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/Collections/GenericIgnoreCaseDictionaryFactory.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/Collections/GenericIgnoreCaseDictionaryFactory.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace MvcSiteMapProvider.Collections
+{
+    /// <summary>
+    /// An abstract factory that can be used to create new instances of <see cref="T:System.Collections.Generic.Dictionary<TKey, TValue>"/>
+    /// at runtime.
+    /// </summary>
+    public class GenericIgnoreCaseDictionaryFactory
+        : IGenericDictionaryFactory
+    {
+
+        #region IGenericDictionaryFactory Members
+
+        public virtual IDictionary<TKey, TValue> Create<TKey, TValue>()
+        {
+            if (typeof(TKey) == typeof(string))
+                return (IDictionary<TKey, TValue>)new Dictionary<string, TValue>(StringComparer.OrdinalIgnoreCase);
+            return new Dictionary<TKey, TValue>();
+        }
+
+        #endregion
+    }
+}

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DI/ConfigurationSettings.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DI/ConfigurationSettings.cs
@@ -32,6 +32,7 @@ namespace MvcSiteMapProvider.DI
             this.SecurityTrimmingEnabled = bool.Parse(GetConfigurationValueOrFallback("MvcSiteMapProvider_SecurityTrimmingEnabled", "false"));
             this.EnableSitemapsXml = bool.Parse(GetConfigurationValueOrFallback("MvcSiteMapProvider_EnableSitemapsXml", "true"));
             this.EnableResolvedUrlCaching = bool.Parse(GetConfigurationValueOrFallback("MvcSiteMapProvider_EnableResolvedUrlCaching", "true"));
+            this.UrlIgnoreCase = bool.Parse(GetConfigurationValueOrFallback("MvcSiteMapProvider_UrlIgnoreCase", "false"));
         }
 
         public bool UseExternalDIContainer { get; private set; }
@@ -50,6 +51,7 @@ namespace MvcSiteMapProvider.DI
         public bool SecurityTrimmingEnabled { get; private set; }
         public bool EnableSitemapsXml { get; private set; }
         public bool EnableResolvedUrlCaching { get; private set; }
+        public bool UrlIgnoreCase { get; private set; }
 
 
         private string GetConfigurationValueOrFallback(string name, string defaultValue)

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DI/SiteMapFactoryContainer.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DI/SiteMapFactoryContainer.cs
@@ -74,6 +74,7 @@ namespace MvcSiteMapProvider.DI
         {
             return new SiteMapChildStateFactory(
                 new GenericDictionaryFactory(),
+                this.settings.UrlIgnoreCase ? new GenericIgnoreCaseDictionaryFactory() : null,
                 new SiteMapNodeCollectionFactory()
                 );
         }

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/ISiteMapChildStateFactory.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/ISiteMapChildStateFactory.cs
@@ -11,6 +11,7 @@ namespace MvcSiteMapProvider
     public interface ISiteMapChildStateFactory
     {
         IDictionary<TKey, TValue> CreateGenericDictionary<TKey, TValue>();
+        IDictionary<TKey, TValue> CreateGenericDictionaryForUrlKey<TKey, TValue>();
         ISiteMapNodeCollection CreateSiteMapNodeCollection();
         ISiteMapNodeCollection CreateLockableSiteMapNodeCollection(ISiteMap siteMap);
         ISiteMapNodeCollection CreateReadOnlySiteMapNodeCollection(ISiteMapNodeCollection siteMapNodeCollection);

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/MvcSiteMapProvider.csproj
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/MvcSiteMapProvider.csproj
@@ -171,6 +171,7 @@
     <Compile Include="Caching\SiteMapCacheKeyGenerator.cs" />
     <Compile Include="Caching\SiteMapCacheKeyToBuilderSetMapper.cs" />
     <Compile Include="ChangeFrequency.cs" />
+    <Compile Include="Collections\GenericIgnoreCaseDictionaryFactory.cs" />
     <Compile Include="Collections\GenericDictionaryFactory.cs" />
     <Compile Include="Collections\IGenericDictionaryFactory.cs" />
     <Compile Include="Collections\IThreadSafeDictionary.cs" />

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/SiteMap.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/SiteMap.cs
@@ -51,7 +51,7 @@ namespace MvcSiteMapProvider
             this.childNodeCollectionTable = siteMapChildStateFactory.CreateGenericDictionary<ISiteMapNode, ISiteMapNodeCollection>();
             this.keyTable = siteMapChildStateFactory.CreateGenericDictionary<string, ISiteMapNode>();
             this.parentNodeTable = siteMapChildStateFactory.CreateGenericDictionary<ISiteMapNode, ISiteMapNode>();
-            this.urlTable = siteMapChildStateFactory.CreateGenericDictionary<string, ISiteMapNode>();
+            this.urlTable = siteMapChildStateFactory.CreateGenericDictionaryForUrlKey<string, ISiteMapNode>();
         }
 
         // Services

--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/SiteMapChildStateFactory.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/SiteMapChildStateFactory.cs
@@ -14,6 +14,7 @@ namespace MvcSiteMapProvider
     {
         public SiteMapChildStateFactory(
             IGenericDictionaryFactory genericDictionaryFactory,
+            IGenericDictionaryFactory genericDictionaryFactoryForUrlKey,
             ISiteMapNodeCollectionFactory siteMapNodeCollectionFactory
             )
         {
@@ -23,10 +24,20 @@ namespace MvcSiteMapProvider
                 throw new ArgumentNullException("siteMapNodeCollectionFactory");
 
             this.genericDictionaryFactory = genericDictionaryFactory;
+            this.genericDictionaryFactoryForUrlKey = genericDictionaryFactoryForUrlKey ?? genericDictionaryFactoryForUrlKey;
             this.siteMapNodeCollectionFactory = siteMapNodeCollectionFactory;
         }
 
+        public SiteMapChildStateFactory(
+            IGenericDictionaryFactory genericDictionaryFactory,
+            ISiteMapNodeCollectionFactory siteMapNodeCollectionFactory
+            )
+            : this(genericDictionaryFactory, genericDictionaryFactory, siteMapNodeCollectionFactory)
+        {
+        }
+
         protected readonly IGenericDictionaryFactory genericDictionaryFactory;
+        protected readonly IGenericDictionaryFactory genericDictionaryFactoryForUrlKey;
         protected readonly ISiteMapNodeCollectionFactory siteMapNodeCollectionFactory;
 
         #region ISiteMapChildStateFactory Members
@@ -34,6 +45,11 @@ namespace MvcSiteMapProvider
         public IDictionary<TKey, TValue> CreateGenericDictionary<TKey, TValue>()
         {
             return genericDictionaryFactory.Create<TKey, TValue>();
+        }
+
+        public IDictionary<TKey, TValue> CreateGenericDictionaryForUrlKey<TKey, TValue>()
+        {
+            return genericDictionaryFactoryForUrlKey.Create<TKey, TValue>();
         }
 
         public ISiteMapNodeCollection CreateSiteMapNodeCollection()


### PR DESCRIPTION
This is a patch for issue #249 Node.IsCurrentNode is case sensitive. Not only IsCurrentNode but also  FindSiteMapNode(string rawUrl) is affected.
It'd be appreciated if you could review this.
