### PR TITLE
Enabling attribute routes and RouteCollectionRoute

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/SiteMap.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/SiteMap.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Web;
 using System.Web.UI;
 using System.Web.Mvc;
@@ -673,6 +674,10 @@ namespace MvcSiteMapProvider
             var routeData = routes.GetRouteData(httpContext);
             if (routeData != null)
             {
+                if (routeData.Values.ContainsKey("MS_DirectRouteMatches"))
+                {
+                    routeData = ((IEnumerable<RouteData>)routeData.Values["MS_DirectRouteMatches"]).First();
+                }
                 if (!routeData.Values.ContainsKey("area"))
                 {
                     if (routeData.DataTokens["area"] != null)


### PR DESCRIPTION
If you use attribute routing then the SiteMap class will not select the correct RouteData on method FindSiteMapNodeFromMvc. This is because with attribute routing you may get a RouteCollectionRoute when requesting it through GetRouteData(httpContext). This Collection will have route matches on the the MS_DirectRouteMatches value. Then you need to get the correct route data from it this matches. I picked the first one.
This is only two lines of code long and easy to merge. I hope it helps.
