### PR TITLE
Update SiteMapTitleHelperModel.cshtml

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/Html/DisplayTemplates/SiteMapTitleHelperModel.cshtml
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/Web/Html/DisplayTemplates/SiteMapTitleHelperModel.cshtml
@@ -2,4 +2,4 @@
 @using System.Web.Mvc.Html
 @using MvcSiteMapProvider.Web.Html.Models
 
-@if (Model.CurrentNode != null) {Model.CurrentNode.Title;}
+@if (Model.CurrentNode != null) {@Model.CurrentNode.Title;}


### PR DESCRIPTION
Added missing '@' in SiteMapTitleHelperModel.cshtml.

@Html.MvcSiteMap().SiteMapTitle() now works again for Razor views, without the '@' you get an 'System.Web.HttpCompileException'.
