### PR TITLE
Fixed problem with incorrect GetControllerSessionBehavior accessor

### DIFF
--- a/src/MvcSiteMapProvider/MvcSiteMapProvider/DI/ControllerFactoryDecorator.cs
+++ b/src/MvcSiteMapProvider/MvcSiteMapProvider/DI/ControllerFactoryDecorator.cs
@@ -62,7 +62,7 @@ namespace MvcSiteMapProvider.DI
         }
 
 #if !MVC2 
-        public SessionStateBehavior GetControllerSessionBehavior(RequestContext requestContext, string controllerName)
+        protected override SessionStateBehavior GetControllerSessionBehavior(RequestContext requestContext, string controllerName)
         {
             return this.innerControllerFactory.GetControllerSessionBehavior(requestContext, controllerName);
         }


### PR DESCRIPTION
The accessor for the "GetControllerSessionBehavior"-method in ControllerFactoryDecorator should be protected override instead of public, cause it overrides the protected internal virtual method from DefaultControllerFactory.
Since it's now public it's never called and that results in the this.innerControllerFactory.GetControllerSessionBehavior() never being called.